### PR TITLE
Modified to expand necessary relations for more API data

### DIFF
--- a/api/entities/subtopic.js
+++ b/api/entities/subtopic.js
@@ -20,6 +20,6 @@ export default class SubTopic {
   @ManyToOne(() => Topic, (topic) => topic.subtopics)
   topic
 
-  @OneToMany(() => Question, (question) => question.topic)
+  @OneToMany(() => Question, (question) => question.subtopic)
   questions
 }

--- a/api/routes/topics.js
+++ b/api/routes/topics.js
@@ -25,7 +25,7 @@ const router = Router();
 router.route('/topics')
   .all(isAuthenticated)
   .get((req, res) => {
-    getRepository(Topic).find({ where: { userId: req.user.id } }).then((topics) => {
+    getRepository(Topic).find({ where: { userId: req.user.id }, relations: ['subtopics', 'subtopics.questions', 'questions', 'questions.answer'] }).then((topics) => {
       res.send(topics);
     });
   })
@@ -51,7 +51,7 @@ router.route('/topics/:id')
   .all(isAuthenticated)
   .all((req, res, next) => {
     getRepository(Topic).findOneOrFail(
-      { where: { userId: req.user.id, id: req.params.id } },
+      { where: { userId: req.user.id, id: req.params.id }, relations: ['subtopics', 'subtopics.questions', 'questions', 'questions.answer'] },
     ).then((_foundTopic) => {
       req.topic = _foundTopic;
       next();
@@ -97,7 +97,7 @@ router.route('/topics/:id/subtopics')
   })
   .get((req, res) => {
     getRepository(SubTopic).find(
-      { where: { topic: req.topic } },
+      { where: { topic: req.topic }, relations: ['topic', 'questions', 'questions.answer'] },
     ).then((subtopics) => {
       res.send(subtopics);
     });
@@ -128,7 +128,7 @@ router.route('/topics/:id/subtopics/:id2')
       { where: { userId: req.user.id, id: req.params.id } },
     ).then((_foundTopic) => {
       getRepository(SubTopic).findOneOrFail(
-        { where: { topic: _foundTopic, id: req.params.id2 } },
+        { where: { topic: _foundTopic, id: req.params.id2 }, relations: ['topic', 'questions', 'questions.answer'] },
       ).then((_foundSubTopic) => {
         req.topic = _foundTopic;
         req.subtopic = _foundSubTopic;


### PR DESCRIPTION
More data will be returned to the API caller.

Ex: calls to /topics will return questions with their expanded answers as well as relevant subtopics, in theory allowing us to easily be able to have all of the relevant information to display the question bank with only 1 API call per view. This then will still be present even if the teacher focuses in on a specific topic or subtopic, etc.

Questions are also now fully connected to topics, subtopics, and answers.